### PR TITLE
fix: Remove unused Project interface

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
 import projectsData from '../data/projects.json';
 
-interface Project {
-  name: string;
-  description: string;
-  link?: string;
-  githubLink?: string;
-  liveLink?: string;
-  status?: string;
-}
-
 const Projects: React.FC = () => {
   const { chromeExtensions, githubProjects, websites } = projectsData;
 


### PR DESCRIPTION
- Removed the unused `Project` interface from `src/components/Projects.tsx` to resolve a build warning.