### PR TITLE
docs: Add Google Sheet URL to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 ```
 
 ### 2. Update Content
-Make all your changes, additions, or removals to the projects in the designated **Google Sheet**.
+Make all your changes, additions, or removals to the projects in the designated **[Google Sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vQzIVbzK4ypdzPzP6piHAXf3LvYTuFqRJ2hixI4GNF75hfSWjeWEOKFUbj6S8JwHiH76azirz2BsHTI/pub?gid=0&single=true&output=tsv)**.
 
 ### 3. Update and Deploy
 To publish your changes to the live website, run the following single command in your terminal:


### PR DESCRIPTION
The README.md file explains that the website content is managed via a Google Sheet, but the URL was missing. This change adds the URL to the README.md file, making it easier for users to find the sheet.