### PR TITLE
fix: Remove text truncation from project cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -54,11 +54,6 @@ a {
 
 #projects .card-text {
   flex-grow: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 4; /* Limit to 4 lines */
-  -webkit-box-orient: vertical;
 }
 
 #projects .card .mt-auto {


### PR DESCRIPTION
Removes the CSS properties that were causing the text on project cards to be truncated with an ellipsis after four lines. The full description is now visible.